### PR TITLE
Use copy with binary.

### DIFF
--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -2929,7 +2929,7 @@ pg_copy_from_stdin(PGSQL *pgsql, const char *qname)
 {
 	char sql[BUFSIZE] = { 0 };
 
-	sformat(sql, sizeof(sql), "COPY %s FROM stdin", qname);
+	sformat(sql, sizeof(sql), "COPY %s FROM stdin WITH (format binary)", qname);
 
 	char *endpoint =
 		pgsql->connectionType == PGSQL_CONN_SOURCE ? "SOURCE" : "TARGET";
@@ -3073,7 +3073,7 @@ pg_copy_send_query(PGSQL *pgsql, CopyArgs *args, ExecStatusType status)
 							  args->srcAttrList,
 							  args->srcQname);
 		}
-		appendPQExpBuffer(sql, "to stdout");
+		appendPQExpBuffer(sql, "to stdout with (format binary);");
 	}
 	else if (status == PGRES_COPY_IN)
 	{
@@ -3090,7 +3090,7 @@ pg_copy_send_query(PGSQL *pgsql, CopyArgs *args, ExecStatusType status)
 
 		if (args->freeze)
 		{
-			appendPQExpBuffer(sql, " with (freeze)");
+			appendPQExpBuffer(sql, " with (freeze, format binary)");
 		}
 	}
 	else

--- a/src/bin/pgcopydb/table-data.c
+++ b/src/bin/pgcopydb/table-data.c
@@ -1440,6 +1440,8 @@ copydb_prepare_copy_query(CopyTableDataSpec *tableSpecs, CopyArgs *args)
 			}
 		}
 
+		appendPQExpBuffer(srcWhereClause, " WITH (FORMAT BINARY)");
+
 		if (PQExpBufferBroken(srcWhereClause))
 		{
 			log_error("Failed to create where clause for %s: out of memory",


### PR DESCRIPTION
- The binary format is a little faster than the text format (https://www.postgresql.org/docs/current/sql-copy.html).  
- It's also useful in cases where the data stored in the BYTEA column, wherein the size in text format may exceed the 1GB field limit size of PostgreSQL.

```
pgsql.c:3159              [SOURCE 836084] [XX000] ERROR:  invalid memory alloc request size 1119193891
pgsql.c:3174              [SOURCE 836084] Context: Failed to fetch data from source
pgsql.c:3159              [TARGET 5216] [57014] ERROR:  COPY from stdin failed: Failed to get data from source
```